### PR TITLE
Spring Security Config 버그 수정 및 Filter 위치 수정

### DIFF
--- a/backend/src/main/java/withdog/common/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/withdog/common/jwt/JwtAuthorizationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import withdog.common.constant.ApiResponseCode;
 import withdog.common.constant.TokenType;
@@ -30,12 +31,18 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return new AntPathRequestMatcher("/api/v1/login", "POST").matches(request);
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("JwtAuthorizationFilter doFilterInternal");
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            //TODO 응답 수정필요
+            log.info("authorization is null");
+            SecurityContextHolder.clearContext();
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
기존 /api/v1/places/{id}/bookmarks RequestMatchers GET 설정 -> POST 설정으로 버그 수정, 기존에 api 요청시 예상치 못한 예외 발생, JwtAuthorizationFilter 의 Filter 위치를 JwtAuthenticationFilter 앞에서 AuthorizationFilter로 수정 -> 모호한 순서를 확실하게 정리